### PR TITLE
27 rdfiolib grab rdftype for rdfnode type identifier uri

### DIFF
--- a/src/Core/CimModel/Schema/RdfSchema/CimRdfSchemaSerializer.cs
+++ b/src/Core/CimModel/Schema/RdfSchema/CimRdfSchemaSerializer.cs
@@ -63,17 +63,8 @@ public class CimRdfSchemaSerializer(RdfReaderBase rdfReader)
                 continue;
             }
 
-            var type = node.Triples.Where(t => RdfUtils
-                    .RdfUriEquals(t.Predicate, CimRdfSchemaStrings.RdfType))
-                .Single().Object as RdfTripleObjectUriContainer;
-
-            if (type == null)
-            {
-                continue;
-            }
-
-            if (_SerializeHelper.TryGetTypeInfo(type.UriObject.AbsoluteUri, 
-                    out var typeInfo)
+            if (_SerializeHelper.TryGetTypeInfo(node.TypeIdentifier
+                .AbsoluteUri.ToLower(), out var typeInfo)
                 && typeInfo != null)
             {
                 if (Activator.CreateInstance(typeInfo, node.Identifier) 
@@ -99,16 +90,7 @@ public class CimRdfSchemaSerializer(RdfReaderBase rdfReader)
     {
         foreach (var node in nodes)
         {
-            var type = node.Triples.Where(t => RdfUtils
-                .RdfUriEquals(t.Predicate, CimRdfSchemaStrings.RdfType))
-            .Single().Object as RdfTripleObjectUriContainer;
-
-            if (type == null)
-            {
-                continue;
-            }
-
-            if ((_ObjectsCache.TryGetValue(type.UriObject, out var entity)
+            if ((_ObjectsCache.TryGetValue(node.TypeIdentifier, out var entity)
                 && entity is CimRdfsClass metaClass) == false)
             {
                 continue;
@@ -140,7 +122,7 @@ public class CimRdfSchemaSerializer(RdfReaderBase rdfReader)
             foreach (var triple in node.Triples)
             {
                 var result = _SerializeHelper
-                    .TryGetMemberInfo(triple.Predicate.AbsoluteUri, 
+                    .TryGetMemberInfo(triple.Predicate.AbsoluteUri.ToLower(), 
                         out var memberInfo);
 
                 if (result == false || memberInfo == null)
@@ -177,8 +159,8 @@ public class CimRdfSchemaSerializer(RdfReaderBase rdfReader)
                     && value is RdfTripleObjectUriContainer valueEnumUriContainer)
                 {
                     _SerializeHelper.TryGetMemberInfo(valueEnumUriContainer
-                        .UriObject.AbsoluteUri, out var field);
-                    _SerializeHelper.TryGetTypeInfo(attribute.Identifier, 
+                        .UriObject.AbsoluteUri.ToLower(), out var field);
+                    _SerializeHelper.TryGetTypeInfo(attribute.Identifier.ToLower(), 
                         out var enumClass);
 
                     if (field != null && enumClass != null)

--- a/src/Core/RdfIOLib/RdfCoreTypes.cs
+++ b/src/Core/RdfIOLib/RdfCoreTypes.cs
@@ -29,7 +29,7 @@ public class RdfNode
     /// <summary>
     /// Rdf resource node identifier.
     /// </summary>
-    public Uri TypeIdentifier { get; }
+    public Uri TypeIdentifier { get; internal set; }
 
     /// <summary>
     /// Rdf node's triples collection.
@@ -127,7 +127,8 @@ public sealed class RdfTripleObjectLiteralContainer
         {
             if (RawObject is not string literalObject)
             {
-                throw new InvalidCastException("RdfTripleObjectLiteralContainer does not contain string object!");
+                throw new InvalidCastException(
+                    "RdfTripleObjectLiteralContainer does not contain string object!");
             }
 
             return literalObject;
@@ -149,7 +150,8 @@ public sealed class RdfTripleObjectUriContainer
         {
             if (RawObject is not Uri uriObject)
             {
-                throw new InvalidCastException("RdfTripleObjectUriContainer does not contain URI object!");
+                throw new InvalidCastException(
+                    "RdfTripleObjectUriContainer does not contain URI object!");
             }
 
             return uriObject;
@@ -171,7 +173,8 @@ public sealed class RdfTripleObjectStatementsContainer
         {
             if (RawObject is not ICollection<RdfNode> rdfNodes)
             {
-                throw new InvalidCastException("RdfTripleObjectStatementsContainer does not contain ICollection<RdfNode> object!");
+                throw new InvalidCastException(
+                    "RdfTripleObjectStatementsContainer does not contain ICollection<RdfNode> object!");
             }
 
             return rdfNodes;

--- a/src/Core/RdfIOLib/RdfXml/RdfXmlReader.cs
+++ b/src/Core/RdfIOLib/RdfXml/RdfXmlReader.cs
@@ -134,10 +134,18 @@ public sealed class RdfXmlReader : RdfReaderBase
             var predicateInfo = ReadNodeHeader();
             if (predicateInfo.AttributesMap.ContainsKey(rdf + "resource"))
             {
-                rdfNode.NewTriple(
-                    NameToUri(predicateInfo.TypeIdentifier), 
-                    new RdfTripleObjectUriContainer(
-                        NameToUri(predicateInfo.Identifier)));
+                var resourceIRI = NameToUri(predicateInfo.Identifier);
+                var predicateTypeIRI = NameToUri(predicateInfo.TypeIdentifier);
+
+                if (predicateTypeIRI.AbsoluteUri == rdf + "type")
+                {
+                    rdfNode.TypeIdentifier = resourceIRI;
+                }
+                else
+                {
+                    rdfNode.NewTriple(predicateTypeIRI, 
+                        new RdfTripleObjectUriContainer(resourceIRI));
+                }
             }
             else if (subtreeReader.Read() 
                 && subtreeReader.NodeType == XmlNodeType.Text)

--- a/src/Utils/MetaReflectionHelper/MetaReflectionHelper.cs
+++ b/src/Utils/MetaReflectionHelper/MetaReflectionHelper.cs
@@ -74,7 +74,7 @@ public class MetaReflectionHelper
                 .GetCustomAttribute<MetaTypeAttribute>(false);
             if (attribute != null)
             {
-                _Types.TryAdd(attribute.Identifier, type.GetTypeInfo());
+                _Types.TryAdd(attribute.Identifier.ToLower(), type.GetTypeInfo());
 
                 CollectSerializableMembers(type.GetTypeInfo());
             }
@@ -98,7 +98,7 @@ public class MetaReflectionHelper
                 .GetCustomAttribute<MetaTypeAttribute>(false);
             if (attribute != null)
             {
-                _Members.TryAdd(attribute.Identifier, property);
+                _Members.TryAdd(attribute.Identifier.ToLower(), property);
             }
         }
     }


### PR DESCRIPTION
Implemented rdf:type grabbing logic:
1. The xml node type is set first
2. If rdf:type is encountered, the type is redefined.

+ improved rdfs serializer meta fields serching - made invariant for text case (casting to lower).